### PR TITLE
Add localaddr / useipv6 options

### DIFF
--- a/lib/Bot/BasicBot.pm
+++ b/lib/Bot/BasicBot.pm
@@ -391,6 +391,12 @@ sub ssl {
     return $self->{ssl} || 0;
 }
 
+sub localaddr {
+    my $self = shift;
+    $self->{localaddr} = shift if @_;
+    return $self->{localaddr} || 0;
+}
+
 sub nick {
     my $self = shift;
     $self->{nick} = shift if @_;
@@ -490,21 +496,22 @@ sub start_state {
     $kernel->post($self->{IRCNAME}, 'register', 'all');
 
     $kernel->post(
-        $self->{IRCNAME},
-        'connect',
-        {
-            Nick     => $self->nick,
-            Server   => $self->server,
-            Port     => $self->port,
-            Password => $self->password,
-            UseSSL   => $self->ssl,
-            Flood    => $self->flood,
-            $self->charset_encode(
-                Nick     => $self->nick,
-                Username => $self->username,
-                Ircname  => $self->name,
-            ),
-        },
+	$self->{IRCNAME},
+	'connect',
+	{
+	    Nick      => $self->nick,
+	    Server    => $self->server,
+	    Port      => $self->port,
+	    Password  => $self->password,
+	    UseSSL    => $self->ssl,
+	    Flood     => $self->flood,
+	    LocalAddr => $self->localaddr,
+	    $self->charset_encode(
+		Nick     => $self->nick,
+		Username => $self->username,
+		Ircname  => $self->name,
+	    ),
+	},
     );
 
     return;
@@ -1316,6 +1323,11 @@ undef.
 
 A boolean to indicate whether or not the server we're going to connect to
 is an SSL server.  Defaults to 0.
+
+=head2 C<localaddr>
+
+The local address to use, for multihomed boxes.  Defaults to undef (use whatever
+source IP address the system deigns is appropriate).
 
 =head2 C<nick>
 

--- a/lib/Bot/BasicBot.pm
+++ b/lib/Bot/BasicBot.pm
@@ -397,6 +397,12 @@ sub localaddr {
     return $self->{localaddr} || 0;
 }
 
+sub useipv6 {
+    my $self = shift;
+    $self->{useipv6} = shift if @_;
+    return $self->{useipv6} || 0;
+}
+
 sub nick {
     my $self = shift;
     $self->{nick} = shift if @_;
@@ -506,6 +512,7 @@ sub start_state {
 	    UseSSL    => $self->ssl,
 	    Flood     => $self->flood,
 	    LocalAddr => $self->localaddr,
+            useipv6   => $self->useipv6,
 	    $self->charset_encode(
 		Nick     => $self->nick,
 		Username => $self->username,
@@ -1328,6 +1335,11 @@ is an SSL server.  Defaults to 0.
 
 The local address to use, for multihomed boxes.  Defaults to undef (use whatever
 source IP address the system deigns is appropriate).
+
+=head C<useipv6>
+
+A boolean to indicate whether IPv6 should be used.  Defaults to undef (use
+IPv4).
 
 =head2 C<nick>
 


### PR DESCRIPTION
Adding support for PoCo::IRC's `LocalAddr` / `useipv6` options, to allow the source IP address used for the connection to be selected (useful on boxes with multiple source IPs available, like an IPv6 block), and to tell PoCo::IRC to use IPv6.
