### PR TITLE
Populate raw_nick for chanjoin in line with said

### DIFF
--- a/lib/Bot/BasicBot.pm
+++ b/lib/Bot/BasicBot.pm
@@ -735,6 +735,7 @@ sub irc_chan_received_state {
     my $return;
     my $mess = {};
     $mess->{who} = $self->nick_strip($nick);
+    $mess->{raw_nick} = $nick;
 
     $mess->{channel} = $channel;
     $mess->{body} = $received; #chanjoin or chanpart


### PR DESCRIPTION
The docs indicate that the hashref passed to chanjoin is similar to that passed to said. This fix populates raw_nick for the hasref passed to chanjoin to make it ever so slightly more similar to the one passed to said.
