### PR TITLE
Fixing incorrect Dist::Zilla phase declaration in Prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,7 +14,7 @@ github_user        = hinrik
 git_tag_message    = CPAN release %v
 no_AutoPrereq      = 1
 
-[Prereqs / Runtime]
+[Prereqs]
 IRC::Utils          = 0
 POE                 = 0
 POE::Component::IRC = 6.62


### PR DESCRIPTION
Based on
http://search.cpan.org/dist/Dist-Zilla/lib/Dist/Zilla/Plugin/Prereqs.pm#DESCRIPTION
you either need to specify the phase and the relationship or just the
relationship if the phase is the default "runtime" phase. Since the relationship is not specified, I just removed the "/" notation.
Now it builds with Dist::Zilla version 5.037 at least.
