### PR TITLE
Support webirc

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,5 +18,5 @@ no_AutoPrereq      = 1
 [Prereqs / RuntimeRequires]
 IRC::Utils          = 0
 POE                 = 0
-POE::Component::IRC = 6.62
+POE::Component::IRC = 6.90
 Text::Wrap          = 0

--- a/lib/Bot/BasicBot.pm
+++ b/lib/Bot/BasicBot.pm
@@ -489,6 +489,12 @@ sub no_run {
     return $self->{no_run};
 }
 
+sub webirc {
+    my $self = shift;
+    $self->{webirc} = shift if @_;
+    return $self->{webirc};
+}
+
 sub start_state {
     my ($self, $kernel, $session) = @_[OBJECT, KERNEL, SESSION];
     $kernel->sig('DIE', 'die');
@@ -519,6 +525,7 @@ sub start_state {
 	    Flood     => $self->flood,
 	    LocalAddr => $self->localaddr,
             useipv6   => $self->useipv6,
+            WebIRC    => $self->webirc,
 	    $self->charset_encode(
 		Nick     => $self->nick,
 		Username => $self->username,
@@ -1447,6 +1454,12 @@ Set to '1' to disable the built-in flood protection of POE::Compoent::IRC
 
 Tells Bot::BasicBot to B<not> run the L<POE kernel|POE::Kernel> at the end
 of L<C<run>|/run>, in case you want to do that yourself.
+
+=head2 C<webirc>
+
+A hashref of WEBIRC params - keys C<user>, C<pass>, C<host> and C<ip>.  Unless
+the network you are connecting to trusts you enough to give you a WEBIRC config
+block & password, this won't be of any use to you.
 
 =head1 OTHER METHODS
 

--- a/lib/Bot/BasicBot.pm
+++ b/lib/Bot/BasicBot.pm
@@ -525,7 +525,7 @@ sub start_state {
 	    Flood     => $self->flood,
 	    LocalAddr => $self->localaddr,
             useipv6   => $self->useipv6,
-            WebIRC    => $self->webirc,
+            webirc    => $self->webirc,
 	    $self->charset_encode(
 		Nick     => $self->nick,
 		Username => $self->username,


### PR DESCRIPTION
Basic, simple WEBIRC support.

If we have a webirc parameter (a hashref of user, pass, host and ip) then send a WEBIRC command to the server upon connection.

Probably not of much use to that many people, as the server you're connecting to needs to be configured to support WEBIRC commands (naturally, any decent server operator will *not* want to give out the ability to spoof any IP/hostname lightly!).

Won't do anything at all unless bingos/poe-component-irc#14 is accepted and merged, so this PR cannot be merged until then.