### PR TITLE
Look for channel keys to pass on

### DIFF
--- a/lib/Bot/BasicBot.pm
+++ b/lib/Bot/BasicBot.pm
@@ -580,11 +580,15 @@ sub irc_001_state {
 
     # connect to the channel
     for my $channel ($self->channels) {
+        my @args = $self->charset_encode($channel);
+        if ($self->{channel_keys}{$channel}) {
+            push @args, $self->{channel_keys}{$channel};
+        }
         $self->log("Trying to join '$channel'\n");
         $kernel->post(
             $self->{IRCNAME},
             'join',
-            $self->charset_encode($channel),
+            @args,
         );
     }
 
@@ -1001,12 +1005,13 @@ Bot::BasicBot - simple irc bot baseclass
   package main;
 
   my $bot = UppercaseBot->new(
-      server      => 'irc.example.com',
-      port        => '6667',
-      channels    => ['#bottest'],
-      nick        => 'UppercaseBot',
-      name        => 'John Doe',
-      ignore_list => [ 'laotse', 'georgeburdell' ],
+      server       => 'irc.example.com',
+      port         => '6667',
+      channels     => ['#bottest', '#secret'],
+      channel_keys => { '#secret' => 'hunter2' },
+      nick         => 'UppercaseBot',
+      name         => 'John Doe',
+      ignore_list  => [ 'laotse', 'georgeburdell' ],
   );
   $bot->run();
 
@@ -1492,6 +1497,11 @@ The name that the bot will identify itself as.  Defaults to
 =head2 C<channels>
 
 The channels we're going to connect to.
+
+=head2 C<channel_keys>
+
+An optional hashref of channel => key, for any channels we wish to join
+which have a key (+k) set.
 
 =head2 C<quit_message>
 


### PR DESCRIPTION
This is for RT 107193.

TODO: I'm unsure if I should have irc_mode_state recognise if it's seeing a +k mode, and if so, memorise the new key that was set, so that the bot can rejoin with that new key, but I think that may be confusing, as the bot would still have the original key (or no key) in its config, so it would be able to connect until it was next restarted, at which time it would start using the old key again.  I'm edging towards KISS, here.